### PR TITLE
Add focus selector for toolbar buttons

### DIFF
--- a/src/components/Toolbar/index.less
+++ b/src/components/Toolbar/index.less
@@ -31,7 +31,8 @@
         outline: none;
         cursor: pointer;
         transition: all 0.3s;
-        &:hover {
+        &:hover,
+        &:focus {
           color: #06c;
           background-color: #dcdcdc;
         }


### PR DESCRIPTION
Per #142, this makes the toolbar buttons appear as they do on hover when they receive focus, making it easier for users who rely on the keyboard to determine which button they've tabbed to.