### PR TITLE
fix: height able be string

### DIFF
--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -26,7 +26,7 @@ export interface MDEditorProps extends Omit<React.HTMLAttributes<HTMLDivElement>
   /**
    * The height of the editor.
    */
-  height?: number;
+  height?: number | string;
   /**
    * Custom toolbar heigth
    * @default 29px


### PR DESCRIPTION
`height` does not have to be a number.

height able be string.

So, this pull request make it possible `50%` in height prop.