### PR TITLE
Fix overlay CSS

### DIFF
--- a/src/components/TextArea/index.less
+++ b/src/components/TextArea/index.less
@@ -13,7 +13,7 @@
     word-break: keep-all;
     overflow-wrap: break-word;
     box-sizing: border-box;
-    padding: 0px;
+    padding: 10px;
     margin: 0;
     font-size: 14px;
     line-height: 18px;
@@ -50,6 +50,7 @@
       position: relative;
       margin: 0px;
       word-wrap: pre;
+      word-break: break-word;
       white-space: pre-wrap;
       pointer-events: none;
     }
@@ -63,8 +64,9 @@
       color: inherit;
       overflow: hidden;
       outline: 0;
-      padding: 0;
+      padding: inherit;
       word-wrap: pre;
+      word-break: break-word;
       white-space: pre-wrap;
       -webkit-font-smoothing: antialiased;
       -webkit-text-fill-color: transparent;

--- a/src/components/TextArea/index.less
+++ b/src/components/TextArea/index.less
@@ -51,7 +51,6 @@
       top: 0px;
       left: 0px;
       margin: 0px;
-      z-index: 1;
       pointer-events: none;
     }
     &-input {
@@ -64,7 +63,6 @@
       color: inherit;
       overflow: hidden;
       outline: 0;
-      z-index: -1;
       -webkit-font-smoothing: antialiased;
       -webkit-text-fill-color: transparent;
       &:empty {

--- a/src/components/TextArea/index.less
+++ b/src/components/TextArea/index.less
@@ -51,6 +51,9 @@
       top: 0px;
       left: 0px;
       margin: 0px;
+      width: 100%;
+      height: 100%;
+      word-wrap: pre;
       pointer-events: none;
     }
     &-input {
@@ -63,6 +66,8 @@
       color: inherit;
       overflow: hidden;
       outline: 0;
+      padding: 0;
+      word-wrap: pre;
       -webkit-font-smoothing: antialiased;
       -webkit-text-fill-color: transparent;
       &:empty {

--- a/src/components/TextArea/index.less
+++ b/src/components/TextArea/index.less
@@ -47,7 +47,11 @@
       }
     }
     &-pre {
-      position: relative;
+      position: absolute;
+      top: 0px;
+      left: 0px;
+      margin: 0px;
+      z-index: 1;
       pointer-events: none;
     }
     &-input {
@@ -60,7 +64,7 @@
       color: inherit;
       overflow: hidden;
       outline: 0;
-      padding: 10px;
+      z-index: -1;
       -webkit-font-smoothing: antialiased;
       -webkit-text-fill-color: transparent;
       &:empty {

--- a/src/components/TextArea/index.less
+++ b/src/components/TextArea/index.less
@@ -50,6 +50,7 @@
       position: relative;
       margin: 0px;
       word-wrap: pre;
+      white-space: pre-wrap;
       pointer-events: none;
     }
     &-input {
@@ -64,6 +65,7 @@
       outline: 0;
       padding: 0;
       word-wrap: pre;
+      white-space: pre-wrap;
       -webkit-font-smoothing: antialiased;
       -webkit-text-fill-color: transparent;
       &:empty {

--- a/src/components/TextArea/index.less
+++ b/src/components/TextArea/index.less
@@ -13,7 +13,7 @@
     word-break: keep-all;
     overflow-wrap: break-word;
     box-sizing: border-box;
-    padding: 10px;
+    padding: 0px;
     margin: 0;
     font-size: 14px;
     line-height: 18px;
@@ -47,12 +47,8 @@
       }
     }
     &-pre {
-      position: absolute;
-      top: 0px;
-      left: 0px;
+      position: relative;
       margin: 0px;
-      width: 100%;
-      height: 100%;
       word-wrap: pre;
       pointer-events: none;
     }


### PR DESCRIPTION
This should fix https://github.com/uiwjs/react-md-editor/issues/134 by removing the hardcoded padding and changing relative positioning to absolute. At least I hope it does, it does at least fix the overlay misalignment that was discovered when I tried to use the new work you mentioned in https://github.com/uiwjs/react-md-editor/issues/193.