### PR TITLE
Remove unnecessary then

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ import dynamic from "next/dynamic";
 import { useState } from "react";
 
 const MDEditor = dynamic(
-  () => import("@uiw/react-md-editor").then((mod) => mod.default),
+  () => import("@uiw/react-md-editor"),
   { ssr: false }
 );
 


### PR DESCRIPTION
The import(...).then throws a Typescript error when tested with Next 11 - and is probably not necessary.