### PR TITLE
feat: enable onChange dom event in textareaProps

### DIFF
--- a/src/components/TextArea/Textarea.tsx
+++ b/src/components/TextArea/Textarea.tsx
@@ -9,7 +9,7 @@ import './index.less';
 export interface TextAreaProps extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'value'>, IProps {}
 
 export default function Textarea(props: TextAreaProps) {
-  const { prefixCls, ...other } = props;
+  const { prefixCls, onChange: onChangeFromProps, ...other } = props;
   const { markdown, commands, fullscreen, preview, highlightEnable, extraCommands, tabSize, onChange, dispatch } =
     useContext(EditorContext);
   const textRef = React.useRef<HTMLTextAreaElement>(null);
@@ -59,6 +59,7 @@ export default function Textarea(props: TextAreaProps) {
       onChange={(e) => {
         dispatch && dispatch({ markdown: e.target.value });
         onChange && onChange(e.target.value);
+        onChangeFromProps && onChangeFromProps(e);
       }}
     />
   );

--- a/src/components/TextArea/index.tsx
+++ b/src/components/TextArea/index.tsx
@@ -25,7 +25,7 @@ type RenderTextareaHandle = {
 };
 
 export interface ITextAreaProps
-  extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'value' | 'onChange' | 'onScroll'>,
+  extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'value' | 'onScroll'>,
     IProps {
   value?: string;
   onScroll?: (e: React.UIEvent<HTMLDivElement>) => void;


### PR DESCRIPTION
This PR enables the onChange property in textAreaProps by updating the typescript definition and triggering the `onChange` passed in through props. It is not a breaking change as it only adds to the existing api.