### PR TITLE
Make sure title markers are inserted at beginning of line

### DIFF
--- a/src/commands/title1.tsx
+++ b/src/commands/title1.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { insertAtLineStart } from '../utils/InsertTextAtPosition';
 import { ICommand, TextState, TextAreaTextApi } from './';
 
 export const title1: ICommand = {
@@ -8,10 +9,6 @@ export const title1: ICommand = {
   buttonProps: { 'aria-label': 'Insert title 1', title: 'Insert title 1' },
   icon: <div style={{ fontSize: 18, textAlign: 'left' }}>Title 1</div>,
   execute: (state: TextState, api: TextAreaTextApi) => {
-    let modifyText = `# ${state.selectedText}\n`;
-    if (!state.selectedText) {
-      modifyText = `# `;
-    }
-    api.replaceSelection(modifyText);
+    insertAtLineStart('# ', state.selection.start, api.textArea);
   },
 };

--- a/src/commands/title2.tsx
+++ b/src/commands/title2.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { insertAtLineStart } from '../utils/InsertTextAtPosition';
 import { ICommand, TextState, TextAreaTextApi } from './';
 
 export const title2: ICommand = {
@@ -8,10 +9,6 @@ export const title2: ICommand = {
   buttonProps: { 'aria-label': 'Insert title2', title: 'Insert title 2' },
   icon: <div style={{ fontSize: 16, textAlign: 'left' }}>Title 2</div>,
   execute: (state: TextState, api: TextAreaTextApi) => {
-    let modifyText = `## ${state.selectedText}\n`;
-    if (!state.selectedText) {
-      modifyText = `## `;
-    }
-    api.replaceSelection(modifyText);
+    insertAtLineStart('## ', state.selection.start, api.textArea);
   },
 };

--- a/src/commands/title3.tsx
+++ b/src/commands/title3.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { insertAtLineStart } from '../utils/InsertTextAtPosition';
 import { ICommand, TextState, TextAreaTextApi } from './';
 
 export const title3: ICommand = {
@@ -8,10 +9,6 @@ export const title3: ICommand = {
   buttonProps: { 'aria-label': 'Insert title3', title: 'Insert title 3' },
   icon: <div style={{ fontSize: 15, textAlign: 'left' }}>Title 3</div>,
   execute: (state: TextState, api: TextAreaTextApi) => {
-    let modifyText = `### ${state.selectedText}\n`;
-    if (!state.selectedText) {
-      modifyText = `### `;
-    }
-    api.replaceSelection(modifyText);
+    insertAtLineStart('### ', state.selection.start, api.textArea);
   },
 };

--- a/src/commands/title4.tsx
+++ b/src/commands/title4.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { insertAtLineStart } from '../utils/InsertTextAtPosition';
 import { ICommand, TextState, TextAreaTextApi } from './';
 
 export const title4: ICommand = {
@@ -8,10 +9,6 @@ export const title4: ICommand = {
   buttonProps: { 'aria-label': 'Insert title4', title: 'Insert title 4' },
   icon: <div style={{ fontSize: 14, textAlign: 'left' }}>Title 4</div>,
   execute: (state: TextState, api: TextAreaTextApi) => {
-    let modifyText = `#### ${state.selectedText}\n`;
-    if (!state.selectedText) {
-      modifyText = `#### `;
-    }
-    api.replaceSelection(modifyText);
+    insertAtLineStart('#### ', state.selection.start, api.textArea);
   },
 };

--- a/src/commands/title5.tsx
+++ b/src/commands/title5.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { insertAtLineStart } from '../utils/InsertTextAtPosition';
 import { ICommand, TextState, TextAreaTextApi } from './';
 
 export const title5: ICommand = {
@@ -8,10 +9,6 @@ export const title5: ICommand = {
   buttonProps: { 'aria-label': 'Insert title5', title: 'Insert title 5' },
   icon: <div style={{ fontSize: 12, textAlign: 'left' }}>Title 5</div>,
   execute: (state: TextState, api: TextAreaTextApi) => {
-    let modifyText = `##### ${state.selectedText}\n`;
-    if (!state.selectedText) {
-      modifyText = `##### `;
-    }
-    api.replaceSelection(modifyText);
+    insertAtLineStart('##### ', state.selection.start, api.textArea);
   },
 };

--- a/src/commands/title6.tsx
+++ b/src/commands/title6.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { insertAtLineStart } from '../utils/InsertTextAtPosition';
 import { ICommand, TextState, TextAreaTextApi } from './';
 
 export const title6: ICommand = {
@@ -8,10 +9,6 @@ export const title6: ICommand = {
   buttonProps: { 'aria-label': 'Insert title6', title: 'Insert title 6' },
   icon: <div style={{ fontSize: 12, textAlign: 'left' }}>Title 6</div>,
   execute: (state: TextState, api: TextAreaTextApi) => {
-    let modifyText = `###### ${state.selectedText}\n`;
-    if (!state.selectedText) {
-      modifyText = `###### `;
-    }
-    api.replaceSelection(modifyText);
+    insertAtLineStart('###### ', state.selection.start, api.textArea);
   },
 };

--- a/src/utils/InsertTextAtPosition.ts
+++ b/src/utils/InsertTextAtPosition.ts
@@ -10,7 +10,7 @@ let browserSupportsTextareaTextNodes: any;
  * @param {HTMLElement} input
  * @return {boolean}
  */
-function canManipulateViaTextNodes(input: HTMLTextAreaElement | HTMLInputElement) {
+function canManipulateViaTextNodes(input: HTMLTextAreaElement | HTMLInputElement): boolean {
   if (input.nodeName !== 'TEXTAREA') {
     return false;
   }
@@ -23,11 +23,43 @@ function canManipulateViaTextNodes(input: HTMLTextAreaElement | HTMLInputElement
 }
 
 /**
+ * @param {string} val
+ * @param {number} cursorIdx
+ * @param {HTMLTextAreaElement|HTMLInputElement} input
+ * @return {void}
+ */
+export const insertAtLineStart = (
+  val: string,
+  cursorIdx: number,
+  input: HTMLTextAreaElement | HTMLInputElement,
+): void => {
+  const content = input.value;
+  let startIdx = 0;
+
+  while (cursorIdx--) {
+    let char = content[cursorIdx];
+    if (char === '\n') {
+      startIdx = cursorIdx + 1;
+      break;
+    }
+  }
+
+  input.focus();
+  input.setRangeText(val, startIdx, startIdx);
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+
+  const ss = input.selectionStart;
+  if (ss !== null && ss !== undefined) {
+    input.setSelectionRange(ss + val.length, ss + val.length);
+  }
+};
+
+/**
  * @param {HTMLTextAreaElement|HTMLInputElement} input
  * @param {string} text
  * @returns {void}
  */
-export function insertTextAtPosition(input: HTMLTextAreaElement | HTMLInputElement, text: string) {
+export function insertTextAtPosition(input: HTMLTextAreaElement | HTMLInputElement, text: string): void {
   // Most of the used APIs only work with the field selected
   input.focus();
 

--- a/src/utils/InsertTextAtPosition.ts
+++ b/src/utils/InsertTextAtPosition.ts
@@ -47,11 +47,6 @@ export const insertAtLineStart = (
   input.focus();
   input.setRangeText(val, startIdx, startIdx);
   input.dispatchEvent(new Event('input', { bubbles: true }));
-
-  const ss = input.selectionStart;
-  if (ss !== null && ss !== undefined) {
-    input.setSelectionRange(ss + val.length, ss + val.length);
-  }
 };
 
 /**

--- a/test/commands.test.tsx
+++ b/test/commands.test.tsx
@@ -396,6 +396,19 @@ it('MDEditor commands title1 value === undefined', async () => {
   expect(handleChange).toHaveReturnedWith('# ');
 });
 
+it('MDEditor commands title1 value === test', async () => {
+  const handleChange = jest.fn((value) => value);
+  const { getByLabelText, getByTitle } = render(
+    <MDEditor value='test' textareaProps={{ title: 'textarea' }} onChange={handleChange} commands={[ commands.title1 ]} />
+  );
+  const btn = getByLabelText('Insert title 1');
+  const input = getByTitle('textarea');
+  (input as HTMLTextAreaElement).setSelectionRange(2, 2);
+  
+  fireEvent(btn, new MouseEvent('click', { bubbles: true, cancelable: true }));
+  expect(handleChange).toHaveReturnedWith('# test');
+});
+
 it('MDEditor commands title2 value === undefined', async () => {
   const handleChange = jest.fn((value) => value);
   const { getByLabelText,getByTitle } = render(
@@ -409,6 +422,18 @@ it('MDEditor commands title2 value === undefined', async () => {
   expect(handleChange).toHaveReturnedWith('## ');
 });
 
+it('MDEditor commands title2 value === test', async () => {
+  const handleChange = jest.fn((value) => value);
+  const { getByLabelText,getByTitle } = render(
+    <MDEditor value='test' onChange={handleChange} textareaProps={{ title: 'test' }} commands={[ commands.title2 ]} />
+  );
+  const input = getByTitle('test');
+  (input as any).setSelectionRange(2, 2)
+  const btn = getByLabelText('Insert title2');
+  fireEvent(btn, new MouseEvent('click', { bubbles: true, cancelable: true }));
+  expect(handleChange).toHaveReturnedWith('## test');
+});
+
 
 it('MDEditor commands title3 value === undefined', async () => {
   const handleChange = jest.fn((value) => value);
@@ -420,6 +445,18 @@ it('MDEditor commands title3 value === undefined', async () => {
   expect(handleChange).toHaveReturnedWith('### ');
 });
 
+it('MDEditor commands title3 value === test', async () => {
+  const handleChange = jest.fn((value) => value);
+  const { getByLabelText, getByTitle } = render(
+    <MDEditor value='test' textareaProps={{ title: 'textarea' }} onChange={handleChange} commands={[ commands.title3 ]} />
+  );
+  const btn = getByLabelText('Insert title3');
+  const input = getByTitle('textarea');
+  (input as any).setSelectionRange(2, 2);
+  fireEvent(btn, new MouseEvent('click', { bubbles: true, cancelable: true }));
+  expect(handleChange).toHaveReturnedWith('### test');
+});
+
 
 it('MDEditor commands title4 value === undefined', async () => {
   const handleChange = jest.fn((value) => value);
@@ -429,6 +466,18 @@ it('MDEditor commands title4 value === undefined', async () => {
   const btn = getByLabelText('Insert title4');
   fireEvent(btn, new MouseEvent('click', { bubbles: true, cancelable: true }));
   expect(handleChange).toHaveReturnedWith('#### ');
+});
+
+it('MDEditor commands title4 value === test', async () => {
+  const handleChange = jest.fn((value) => value);
+  const { getByLabelText, getByTitle } = render(
+    <MDEditor value='test' textareaProps={{title: 'textarea'}} onChange={handleChange} commands={[ commands.title4 ]} />
+  );
+  const btn = getByLabelText('Insert title4');
+  const input = getByTitle('textarea');
+  (input as any).setSelectionRange(2, 2);
+  fireEvent(btn, new MouseEvent('click', { bubbles: true, cancelable: true }));
+  expect(handleChange).toHaveReturnedWith('#### test');
 });
 
 
@@ -443,6 +492,19 @@ it('MDEditor commands title5 value === undefined', async () => {
 });
 
 
+it('MDEditor commands title5 value === test', async () => {
+  const handleChange = jest.fn((value) => value);
+  const { getByLabelText, getByTitle } = render(
+    <MDEditor value='test' textareaProps={{title: 'textarea'}} onChange={handleChange} commands={[ commands.title5 ]} />
+  );
+  const btn = getByLabelText('Insert title5');
+  const input = getByTitle('textarea');
+  (input as any).setSelectionRange(2, 2);
+  fireEvent(btn, new MouseEvent('click', { bubbles: true, cancelable: true }));
+  expect(handleChange).toHaveReturnedWith('##### test');
+});
+
+
 it('MDEditor commands title6 value === undefined', async () => {
   const handleChange = jest.fn((value) => value);
   const { getByLabelText } = render(
@@ -451,4 +513,16 @@ it('MDEditor commands title6 value === undefined', async () => {
   const btn = getByLabelText('Insert title6');
   fireEvent(btn, new MouseEvent('click', { bubbles: true, cancelable: true }));
   expect(handleChange).toHaveReturnedWith('###### ');
+});
+
+it('MDEditor commands title6 value === test', async () => {
+  const handleChange = jest.fn((value) => value);
+  const { getByLabelText, getByTitle } = render(
+    <MDEditor value='test' textareaProps={{title: 'textarea'}} onChange={handleChange} commands={[ commands.title6 ]} />
+  );
+  const btn = getByLabelText('Insert title6');
+  const input = getByTitle('textarea');
+  (input as any).setSelectionRange(2, 2);
+  fireEvent(btn, new MouseEvent('click', { bubbles: true, cancelable: true }));
+  expect(handleChange).toHaveReturnedWith('###### test');
 });


### PR DESCRIPTION
The current behavior of the title command inserts the `#` at the current cursor position which is invalid. This PR finds the beginning of the line and inserts the `#` to create valid markdown syntax. 