### PR TITLE
Add new defaultTabEnable property that is set to false by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,7 @@ export default HomePage;
 - `maxHeight?: number=1200`: Maximum drag height. The `visiableDragbar=true` value is valid.
 - `minHeights?: number=100`: Minimum drag height. The `visiableDragbar=true` value is valid.
 - `tabSize?: number=2`: The number of characters to insert when pressing tab key. Default `2` spaces.
+- `defaultTabEnable?: boolean=false`: If `false`, the `tab` key insert a tab character into the textarea. If `true`, the `tab` key executes default behavior e.g. focus shifts to next element. 
 - `hideToolbar?: boolean=false`: Option to hide the tool bar.
 - `enableScroll?: boolean=true`: Whether to enable scrolling.
 

--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ export default HomePage;
 - `maxHeight?: number=1200`: Maximum drag height. The `visiableDragbar=true` value is valid.
 - `minHeights?: number=100`: Minimum drag height. The `visiableDragbar=true` value is valid.
 - `tabSize?: number=2`: The number of characters to insert when pressing tab key. Default `2` spaces.
-- `defaultTabEnable?: boolean=false`: If `false`, the `tab` key insert a tab character into the textarea. If `true`, the `tab` key executes default behavior e.g. focus shifts to next element. 
+- `defaultTabEnable?: boolean=false`: If `false`, the `tab` key inserts a tab character into the textarea. If `true`, the `tab` key executes default behavior e.g. focus shifts to next element. 
 - `hideToolbar?: boolean=false`: Option to hide the tool bar.
 - `enableScroll?: boolean=true`: Whether to enable scrolling.
 

--- a/src/Context.tsx
+++ b/src/Context.tsx
@@ -22,6 +22,7 @@ export type ContextStore = {
   scrollTop?: number;
   scrollTopPreview?: number;
   tabSize?: number;
+  defaultTabEnable?: boolean;
 };
 
 export type ExecuteCommandState = Pick<ContextStore, 'fullscreen' | 'preview' | 'highlightEnable'>;

--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -77,7 +77,7 @@ export interface MDEditorProps extends Omit<React.HTMLAttributes<HTMLDivElement>
    */
   tabSize?: number;
   /**
-   * If `false`, the `tab` key insert a tab character into the textarea. If `true`, the `tab` key executes default behavior e.g. focus shifts to next element.
+   * If `false`, the `tab` key inserts a tab character into the textarea. If `true`, the `tab` key executes default behavior e.g. focus shifts to next element.
    */
   defaultTabEnable?: boolean;
   /**

--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -77,6 +77,10 @@ export interface MDEditorProps extends Omit<React.HTMLAttributes<HTMLDivElement>
    */
   tabSize?: number;
   /**
+   * If `false`, the `tab` key insert a tab character into the textarea. If `true`, the `tab` key executes default behavior e.g. focus shifts to next element.
+   */
+  defaultTabEnable?: boolean;
+  /**
    * You can create your own commands or reuse existing commands.
    */
   commands?: ICommand[];
@@ -128,12 +132,12 @@ const InternalMDEditor = (
     minHeight = 100,
     autoFocus,
     tabSize = 2,
+    defaultTabEnable = false,
     onChange,
     hideToolbar,
     renderTextarea,
     ...other
   } = props || {};
-
   const cmds = commands
     .map((item) => (commandsFilter ? commandsFilter(item, false) : item))
     .filter(Boolean) as ICommand[];
@@ -146,6 +150,7 @@ const InternalMDEditor = (
     height,
     highlightEnable,
     tabSize,
+    defaultTabEnable,
     scrollTop: 0,
     scrollTopPreview: 0,
     commands: cmds,

--- a/src/components/TextArea/Textarea.tsx
+++ b/src/components/TextArea/Textarea.tsx
@@ -10,8 +10,17 @@ export interface TextAreaProps extends Omit<React.TextareaHTMLAttributes<HTMLTex
 
 export default function Textarea(props: TextAreaProps) {
   const { prefixCls, onChange, ...other } = props;
-  const { markdown, commands, fullscreen, preview, highlightEnable, extraCommands, tabSize, dispatch } =
-    useContext(EditorContext);
+  const {
+    markdown,
+    commands,
+    fullscreen,
+    preview,
+    highlightEnable,
+    extraCommands,
+    tabSize,
+    defaultTabEnable,
+    dispatch,
+  } = useContext(EditorContext);
   const textRef = React.useRef<HTMLTextAreaElement>(null);
   const executeRef = React.useRef<TextAreaCommandOrchestrator>();
   const statesRef = React.useRef<ExecuteCommandState>({ fullscreen, preview });
@@ -30,7 +39,7 @@ export default function Textarea(props: TextAreaProps) {
   }, []);
 
   const onKeyDown = (e: KeyboardEvent | React.KeyboardEvent<HTMLTextAreaElement>) => {
-    handleKeyDown(e, tabSize);
+    handleKeyDown(e, tabSize, defaultTabEnable);
     shortcuts(e, [...(commands || []), ...(extraCommands || [])], executeRef.current, dispatch, statesRef.current);
   };
   useEffect(() => {

--- a/src/components/TextArea/handleKeyDown.tsx
+++ b/src/components/TextArea/handleKeyDown.tsx
@@ -14,16 +14,18 @@ function stopPropagation(e: KeyboardEvent | React.KeyboardEvent<HTMLTextAreaElem
 export default function handleKeyDown(
   e: KeyboardEvent | React.KeyboardEvent<HTMLTextAreaElement>,
   tabSize: number = 2,
+  defaultTabEnable: boolean = false,
 ) {
   const target = e.target as HTMLTextAreaElement;
   const starVal = target.value.substr(0, target.selectionStart);
   const valArr = starVal.split('\n');
   const currentLineStr = valArr[valArr.length - 1];
   const textArea = new TextAreaTextApi(target);
+
   /**
    * `9` - `Tab`
    */
-  if (e.code && e.code.toLowerCase() === 'tab') {
+  if (!defaultTabEnable && e.code && e.code.toLowerCase() === 'tab') {
     stopPropagation(e);
     const space = new Array(tabSize + 1).join('  ');
     if (target.selectionStart !== target.selectionEnd) {

--- a/website/ExampleCustomToolbar.tsx
+++ b/website/ExampleCustomToolbar.tsx
@@ -8,10 +8,11 @@ const ExampleCustomToolbar = () => {
     buttonProps: null,
     icon: <span style={{ padding: '0 5px' }}>Custom Toolbar</span>,
   };
-  const [value, setValue] = useState('Hello Markdown!');
+  const [value, setValue] = useState('Hello Markdown! `Tab` key uses default behavior');
 
   return (
     <MDEditor
+      defaultTabEnable={true}
       value={value}
       onChange={(newValue = '') => setValue(newValue)}
       textareaProps={{


### PR DESCRIPTION
If `false`, the `tab` key inserts a tab character into the textarea. If `true`, the `tab` key executes default behaviour e.g. focus shifts to next element.