### PR TITLE
[FEAT] Add prop on MDEditor to allow Toolbar to pin to bottom of editor

### DIFF
--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -107,6 +107,8 @@ export interface MDEditorProps extends Omit<React.HTMLAttributes<HTMLDivElement>
   hideToolbar?: boolean;
   /** Whether to enable scrolling */
   enableScroll?: boolean;
+  /** Toolbar on bottom */
+  toolbarBottom?: boolean;
 }
 
 function setGroupPopFalse(data: Record<string, boolean> = {}) {
@@ -145,6 +147,7 @@ const InternalMDEditor = (
     onChange,
     onHeightChange,
     hideToolbar,
+    toolbarBottom = false,
     renderTextarea,
     ...other
   } = props || {};
@@ -295,7 +298,9 @@ const InternalMDEditor = (
           height: state.fullscreen ? '100%' : hideToolbar ? Number(state.height) - toolbarHeight : state.height,
         }}
       >
-        {!hideToolbar && <Toolbar prefixCls={prefixCls} height={toolbarHeight} overflow={overflow} />}
+        {!hideToolbar && !toolbarBottom && (
+          <Toolbar prefixCls={prefixCls} height={toolbarHeight} overflow={overflow} toolbarBottom={toolbarBottom} />
+        )}
         <div
           className={`${prefixCls}-content`}
           style={{
@@ -330,6 +335,9 @@ const InternalMDEditor = (
               dispatch({ height: newHeight });
             }}
           />
+        )}
+        {!hideToolbar && toolbarBottom && (
+          <Toolbar prefixCls={prefixCls} height={toolbarHeight} overflow={overflow} toolbarBottom={toolbarBottom} />
         )}
       </div>
     </EditorContext.Provider>

--- a/src/components/Toolbar/index.less
+++ b/src/components/Toolbar/index.less
@@ -10,6 +10,11 @@
     align-items: center;
     border-radius: 3px 3px 0 0;
     user-select: none;
+    &.bottom {
+      border-bottom: 0px;
+      border-top: 1px solid var(--color-border-default);
+      border-radius: 0 0 3px 3px;
+    }
     ul,
     li {
       margin: 0;

--- a/src/components/Toolbar/index.tsx
+++ b/src/components/Toolbar/index.tsx
@@ -8,6 +8,7 @@ import './index.less';
 export interface IToolbarProps extends IProps {
   overflow?: boolean;
   height?: React.CSSProperties['height'];
+  toolbarBottom?: boolean;
   onCommand?: (command: ICommand<string>, groupName?: string) => void;
   commands?: ICommand<string>[];
   isChild?: boolean;
@@ -118,10 +119,11 @@ export function ToolbarItems(props: IToolbarProps) {
 }
 
 export default function Toolbar(props: IToolbarProps = {}) {
-  const { prefixCls, height = 29, isChild } = props;
+  const { prefixCls, height = 29, toolbarBottom, isChild } = props;
   const { commands, extraCommands } = useContext(EditorContext);
+  const bottomClassName = toolbarBottom ? 'bottom' : '';
   return (
-    <div className={`${prefixCls}-toolbar`} style={{ height }}>
+    <div className={`${prefixCls}-toolbar ${bottomClassName}`} style={{ height }}>
       <ToolbarItems {...props} commands={props.commands || commands || []} />
       {!isChild && <ToolbarItems {...props} commands={extraCommands || []} />}
     </div>

--- a/website/Exmaple.tsx
+++ b/website/Exmaple.tsx
@@ -13,6 +13,7 @@ const Exmaple = (props = {} as { mdStr: string }) => {
     enableScroll: true,
     value: props.mdStr || '',
     preview: 'live',
+    toolbarBottom: false,
   });
   const upPreview = (e: React.ChangeEvent<HTMLInputElement>) => {
     setVisiable({ ...state, preview: e.target.value as MDEditorProps['preview'] });
@@ -51,6 +52,7 @@ const Exmaple = (props = {} as { mdStr: string }) => {
         highlightEnable={state.highlightEnable}
         hideToolbar={!state.hideToolbar}
         enableScroll={state.enableScroll}
+        toolbarBottom={state.toolbarBottom}
         visiableDragbar={state.visiableDragbar}
         textareaProps={{
           placeholder: 'Please enter Markdown text',
@@ -100,6 +102,16 @@ const Exmaple = (props = {} as { mdStr: string }) => {
             }}
           />
           {state.hideToolbar ? 'Show' : 'Hidden'} ToolBar
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={!state.toolbarBottom}
+            onChange={(e) => {
+              setVisiable({ ...state, toolbarBottom: !e.target.checked });
+            }}
+          />
+          {!state.toolbarBottom ? 'Top' : 'Bottom'} ToolBar
         </label>
         <label>
           <input


### PR DESCRIPTION
## Purpose
Allow toolbar to pin to bottom.

## Key Changes
- add `toolbarBottom` prop to `MDEditor`
- add checkbox in example for controlling `toolbarBottom`
- slight css change depending on position of toolbar