### PR TITLE
Add comment command to exported commands

### DIFF
--- a/core/src/commands/index.ts
+++ b/core/src/commands/index.ts
@@ -178,6 +178,7 @@ export {
   title6,
   bold,
   codeBlock,
+  comment,
   italic,
   strikethrough,
   hr,


### PR DESCRIPTION
A small fix to allow the command to be put in the `commands` or `extraCommands` attribute.