### PR TITLE
fixed bug with scrolling in next app

### DIFF
--- a/core/src/components/Toolbar/index.tsx
+++ b/core/src/components/Toolbar/index.tsx
@@ -58,7 +58,7 @@ export function ToolbarItems(props: IToolbarProps) {
           originalOverflow.current = window.getComputedStyle(document.body, null).overflow;
         }
         // reset to the original overflow
-        document.body.style.overflow = originalOverflow.current;
+        // document.body.style.overflow = originalOverflow.current;
       }
     }
   }, [fullscreen, originalOverflow, overflow]);


### PR DESCRIPTION
I had a bug with [react-md-editor](https://github.com/uiwjs/react-md-editor) in a nextjs app:
1. open the editor in a chakra-ui drawer
2. close the drawer
3. Now it's impossible to scroll on the page again

I hade to comment out this line to fix the bug for me