### PR TITLE
editor: fix commands changes weren't reflected in editor state

### DIFF
--- a/core/src/Editor.tsx
+++ b/core/src/Editor.tsx
@@ -265,6 +265,8 @@ const InternalMDEditor = (
     () => height !== state.height && onHeightChange && onHeightChange(state.height, height, state),
     [height, onHeightChange, state],
   );
+   // eslint-disable-next-line react-hooks/exhaustive-deps
+   useMemo(() => commands !== state.commands && dispatch({ commands: commands }), [commands]);
 
   const textareaDomRef = useRef<HTMLDivElement>();
   const active = useRef<'text' | 'preview'>('preview');


### PR DESCRIPTION
Plot: I was trying to implement commands which require certain data from root component which helds MDEditor ( one of the formik values ) and due to lack of code i'm purposing there that fields weren't updated and couldn't be achieved. 
This fix allows end-user to enrich commands with any kind of external data.