### PR TITLE
fix(DragBar): Height resets to default value after first drag resize

### DIFF
--- a/core/src/components/DragBar/index.tsx
+++ b/core/src/components/DragBar/index.tsx
@@ -13,6 +13,14 @@ const DragBar: React.FC<IDragBarProps> = (props) => {
   const { prefixCls, onChange } = props || {};
   const $dom = useRef<HTMLDivElement>(null);
   const dragRef = useRef<{ height: number; dragY: number }>();
+  const heightRef = useRef(props.height);
+
+  useEffect(() => {
+    if (heightRef.current !== props.height) {
+      heightRef.current = props.height;
+    }
+  }, [props.height]);
+
   function handleMouseMove(event: Event) {
     if (dragRef.current) {
       const clientY =
@@ -35,7 +43,7 @@ const DragBar: React.FC<IDragBarProps> = (props) => {
     const clientY =
       (event as unknown as MouseEvent).clientY || (event as unknown as TouchEvent).changedTouches[0]?.clientY;
     dragRef.current = {
-      height: props.height,
+      height: heightRef.current,
       dragY: clientY,
     };
     document.addEventListener('mousemove', handleMouseMove);


### PR DESCRIPTION
I created the related issue https://github.com/uiwjs/react-md-editor/issues/501

![image](https://user-images.githubusercontent.com/89025862/230972513-d72a5701-0476-48fc-8eab-10aea9a10ede.png)
