### PR TITLE
fix(docs): when trying to change the font of the md editor, style conflicts occurs and messes up the cursor position

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -511,8 +511,8 @@ export default function App() {
 [![#425](https://img.shields.io/github/issues/detail/state/uiwjs/react-md-editor/425)](https://github.com/uiwjs/react-md-editor/issues/425#issuecomment-1209514536)
 
 ```css
-.w-md-editor-text-pre > code,
-.w-md-editor-text-input {
+body .w-md-editor-text-pre > code,
+body .w-md-editor-text-input {
   font-size: 23px !important;
   line-height: 24px !important;
 }


### PR DESCRIPTION
I faced this issue while using this library and saw several users face the same issue so I'd like to prevent this issue from happening with anyone else again