### PR TITLE
Fix support for asynchronous plugins in rehypePlugins

### DIFF
--- a/core/src/components/TextArea/Markdown.tsx
+++ b/core/src/components/TextArea/Markdown.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { rehype } from 'rehype';
 import rehypePrism from 'rehype-prism-plus';
 import { IProps } from '../../Types';
@@ -7,12 +7,6 @@ import { EditorContext } from '../../Context';
 function html2Escape(sHtml: string) {
   return (
     sHtml
-      // .replace(/```(\w+)?([\s\S]*?)(\s.+)?```/g, (str: string) => {
-      //   return str.replace(
-      //     /[<&"]/g,
-      //     (c: string) => (({ '<': '&lt;', '>': '&gt;', '&': '&amp;', '"': '&quot;' } as Record<string, string>)[c]),
-      //   );
-      // })
       .replace(
         /[<&"]/g,
         (c: string) => (({ '<': '&lt;', '>': '&gt;', '&': '&amp;', '"': '&quot;' }) as Record<string, string>)[c],
@@ -26,30 +20,43 @@ export default function Markdown(props: MarkdownProps) {
   const { prefixCls } = props;
   const { markdown = '', highlightEnable, dispatch } = useContext(EditorContext);
   const preRef = React.createRef<HTMLPreElement>();
+  const [mdStr, setMdStr] = useState('');
+
   useEffect(() => {
     if (preRef.current && dispatch) {
       dispatch({ textareaPre: preRef.current });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-  if (!markdown) {
-    return <pre ref={preRef} className={`${prefixCls}-text-pre wmde-markdown-color`} />;
-  }
-  let mdStr = `<pre class="language-markdown ${prefixCls}-text-pre wmde-markdown-color"><code class="language-markdown">${html2Escape(
-    String.raw`${markdown}`,
-  )}\n</code></pre>`;
 
-  if (highlightEnable) {
-    try {
-      mdStr = rehype()
-        .data('settings', { fragment: true })
-        // https://github.com/uiwjs/react-md-editor/issues/593
-        // @ts-ignore
-        .use(rehypePrism, { ignoreMissing: true })
-        .processSync(mdStr)
-        .toString();
-    } catch (error) {}
-  }
+  useEffect(() => {
+    async function processMarkdown() {
+      if (!markdown) {
+        setMdStr('');
+        return;
+      }
+
+      let mdStr = `<pre class="language-markdown ${prefixCls}-text-pre wmde-markdown-color"><code class="language-markdown">${html2Escape(
+        String.raw`${markdown}`,
+      )}\n</code></pre>`;
+
+      if (highlightEnable) {
+        try {
+          mdStr = await rehype()
+            .data('settings', { fragment: true })
+            // https://github.com/uiwjs/react-md-editor/issues/593
+            // @ts-ignore
+            .use(rehypePrism, { ignoreMissing: true })
+            .process(mdStr)
+            .then((file) => file.toString());
+        } catch (error) {}
+      }
+
+      setMdStr(mdStr);
+    }
+
+    processMarkdown();
+  }, [markdown, highlightEnable, prefixCls]);
 
   return React.createElement('div', {
     className: 'wmde-markdown-color',

--- a/www/src/Example.tsx
+++ b/www/src/Example.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
+import rehypePrettyCode from 'rehype-pretty-code';
 import MDEditor, { MDEditorProps } from '@uiw/react-md-editor';
 import styled from 'styled-components';
 
@@ -51,6 +52,7 @@ const Example = (props = {} as { mdStr: string }) => {
                 },
               },
             ],
+            rehypePrettyCode,
           ],
         }}
         height={400}


### PR DESCRIPTION
Related to #662

Refactor `Markdown` component to support asynchronous plugins.

* **Markdown Component (`core/src/components/TextArea/Markdown.tsx`)**
  - Import `useState` from React.
  - Add `mdStr` state to manage the processed markdown string.
  - Refactor `useEffect` to handle asynchronous processing of markdown using `rehype().process`.
  - Update the return statement to use `mdStr` state.

* **Example Component (`www/src/Example.tsx`)**
  - Import `rehypePrettyCode`.
  - Add `rehypePrettyCode` to `previewOptions.rehypePlugins`.

* **Tests (`test/editor.test.tsx`)**
  - Add a test to verify that `MDEditor` supports asynchronous plugins.
  - Use an example async plugin that adds a class to the first node.
  - Verify that the class is added to the preview node after processing.

