### PR TITLE
feat: autoFocusEnd

### DIFF
--- a/core/src/Context.tsx
+++ b/core/src/Context.tsx
@@ -14,6 +14,7 @@ export interface ContextStore {
   fullscreen?: boolean;
   highlightEnable?: boolean;
   autoFocus?: boolean;
+  autoFocusEnd?: boolean;
   textarea?: HTMLTextAreaElement;
   commandOrchestrator?: TextAreaCommandOrchestrator;
   textareaWarp?: HTMLDivElement;

--- a/core/src/Editor.nohighlight.tsx
+++ b/core/src/Editor.nohighlight.tsx
@@ -38,6 +38,7 @@ const InternalMDEditor = React.forwardRef<RefMDEditor, MDEditorProps>(
       maxHeight = 1200,
       minHeight = 100,
       autoFocus,
+      autoFocusEnd = false,
       tabSize = 2,
       defaultTabEnable = false,
       onChange,
@@ -117,6 +118,7 @@ const InternalMDEditor = React.forwardRef<RefMDEditor, MDEditorProps>(
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
     useMemo(() => autoFocus !== state.autoFocus && dispatch({ autoFocus: autoFocus }), [autoFocus]);
+    useMemo(() => autoFocusEnd !== state.autoFocusEnd && dispatch({ autoFocusEnd: autoFocusEnd }), [autoFocusEnd]);
     useMemo(
       () => fullscreen !== state.fullscreen && dispatch({ fullscreen: fullscreen }),
       // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/core/src/Editor.tsx
+++ b/core/src/Editor.tsx
@@ -38,6 +38,7 @@ const InternalMDEditor = React.forwardRef<RefMDEditor, MDEditorProps>(
       maxHeight = 1200,
       minHeight = 100,
       autoFocus,
+      autoFocusEnd = false,
       tabSize = 2,
       defaultTabEnable = false,
       onChange,
@@ -117,6 +118,7 @@ const InternalMDEditor = React.forwardRef<RefMDEditor, MDEditorProps>(
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
     useMemo(() => autoFocus !== state.autoFocus && dispatch({ autoFocus: autoFocus }), [autoFocus]);
+    useMemo(() => autoFocusEnd !== state.autoFocusEnd && dispatch({ autoFocusEnd: autoFocusEnd }), [autoFocusEnd]);
     useMemo(
       () => fullscreen !== state.fullscreen && dispatch({ fullscreen: fullscreen }),
       // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/core/src/Types.ts
+++ b/core/src/Types.ts
@@ -38,6 +38,10 @@ export interface MDEditorProps extends Omit<React.HTMLAttributes<HTMLDivElement>
    */
   autoFocus?: ITextAreaProps['autoFocus'];
   /**
+   * Can be used to make `Markdown Editor` focus on the end of text on initialization.
+   */
+  autoFocusEnd?: boolean;
+  /**
    * The height of the editor.
    * ⚠️ `Dragbar` is invalid when **`height`** parameter percentage.
    */

--- a/core/src/components/TextArea/Textarea.tsx
+++ b/core/src/components/TextArea/Textarea.tsx
@@ -19,6 +19,7 @@ export default function Textarea(props: TextAreaProps) {
     extraCommands,
     tabSize,
     defaultTabEnable,
+    autoFocusEnd,
     dispatch,
     ...otherStore
   } = useContext(EditorContext);
@@ -37,6 +38,19 @@ export default function Textarea(props: TextAreaProps) {
       dispatch({ textarea: textRef.current, commandOrchestrator });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (autoFocusEnd && textRef.current) {
+      textRef.current.focus();
+      const length = textRef.current.value.length;
+      textRef.current.setSelectionRange(length, length);
+      setTimeout(() => {
+        if (textRef.current) {
+          textRef.current.scrollTop = textRef.current.scrollHeight;
+        }
+      }, 0);
+    }
   }, []);
 
   const onKeyDown = (e: KeyboardEvent | React.KeyboardEvent<HTMLTextAreaElement>) => {


### PR DESCRIPTION
Adding an option to autoFocus on the end of the textarea by setting `autoFocusEnd` to true.

Possible issues:
- scroll preview pane to the end when textarea is scrolled to the end on focus.
- suto scrolling textarea is buggy (it always set focus, but scrolls usually after 2nd mode switch)

I tried to fix these issues, but cannot get it fully working as expected. Probably I don't remember the repo.

Would be great if you could take a look (possibly it is a quick fix).