### PR TITLE
Export keyboard handlers and add documentation for headless mode

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -120,6 +120,49 @@ export default function App() {
 }
 ```
 
+### Headless Mode
+
+The package exposes the necessary utilities to build a headless markdown editor with your own UI. This example creates a simple textarea that supports markdown keyboard shortcuts and correct handling of newlines.
+
+```jsx mdx:preview
+import React from "react";
+import { 
+  handleKeyDown, 
+  shortcuts, 
+  TextAreaCommandOrchestrator,
+  getCommands,
+} from '@uiw/react-md-editor';
+
+export default function App() {
+  const [value, setValue] = React.useState("**Hello world!!!**");
+  const textareaRef = React.useRef(null);
+  const orchestratorRef = React.useRef(null);
+  
+  React.useEffect(() => {
+    if (textareaRef.current) {
+      orchestratorRef.current = new TextAreaCommandOrchestrator(textareaRef.current);
+    }
+  }, []);
+
+  const onKeyDown = (e) => {
+    handleKeyDown(e, 2, false);
+    if (orchestratorRef.current) {
+      shortcuts(e, getCommands(), orchestratorRef.current);
+    }
+  };
+
+  return (
+    <textarea
+      ref={textareaRef}
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      onKeyDown={onKeyDown}
+      style={{ width: '100%', height: 200, padding: 10 }}
+    />
+  );
+}
+```
+
 ### Special Markdown syntax
 
 **Supports for CSS Style**

--- a/core/src/index.tsx
+++ b/core/src/index.tsx
@@ -11,6 +11,8 @@ export * from './utils/InsertTextAtPosition';
 export * from './Editor';
 export * from './Context';
 export * from './Types';
+export { default as handleKeyDown } from './components/TextArea/handleKeyDown';
+export { default as shortcuts } from './components/TextArea/shortcuts';
 
 export { MarkdownUtil, commands };
 


### PR DESCRIPTION
I wanted to use the package for our custom markdown editor, but ran into issues with the default styles that are bundled with the editor.

Then I discovered that the package already exposes almost everything that would be needed to use it as a headless editor (context, reducer, commands, etc) and build a completely custom UI. The only thing that's missing are the keyboard handlers for shortcuts and linebreaks.

It would probably be even better to split this package in two: a "core" package with all the utility functions and an "editor" package with the default UI. This would make it very comfortable to create custom implementations and would fill a niche that seems to be unfilled on NPM - a light, fully featured, fully customisable Markdown editor. But I thought I would start with a smaller non-breaking change.

This PR exposes the missing parts of the editor and adds a short section in README documenting headless mode. As I personally discovered this only when I was about to give up and went to look at source.