### PR TITLE
fix: expose utility functions in nohighlight entrypoint

### DIFF
--- a/core/src/index.nohighlight.tsx
+++ b/core/src/index.nohighlight.tsx
@@ -3,6 +3,7 @@ import * as commands from './commands/';
 import * as MarkdownUtil from './utils/markdownUtils';
 import './index.less';
 
+export { headingExecute } from './commands/title';
 export * from './commands/';
 export * from './commands/group';
 export * from './utils/markdownUtils';
@@ -10,6 +11,8 @@ export * from './utils/InsertTextAtPosition';
 export * from './Editor.nohighlight';
 export * from './Context';
 export * from './Types';
+export { default as handleKeyDown } from './components/TextArea/handleKeyDown';
+export { default as shortcuts } from './components/TextArea/shortcuts';
 
 export { MarkdownUtil, commands };
 


### PR DESCRIPTION
After https://github.com/uiwjs/react-md-editor/pull/697 , there are now utilities that are not exposed in the `nohighlight` entrypoint. This PR fixes this, exposing all the same methods.