### PR TITLE
fix nohighlight typescript declaration

### DIFF
--- a/core/nohighlight.d.ts
+++ b/core/nohighlight.d.ts
@@ -10,6 +10,8 @@ declare module '@uiw/react-md-editor/nohighlight' {
   export * from '@uiw/react-md-editor/esm/Editor.nohighlight';
   export * from '@uiw/react-md-editor/esm/Context';
   export * from '@uiw/react-md-editor/esm/Types';
+  export { default as handleKeyDown } from '@uiw/react-md-editor/esm/components/TextArea/handleKeyDown';
+  export { default as shortcuts } from '@uiw/react-md-editor/esm/components/TextArea/shortcuts';
   export { MarkdownUtil, commands };
   export default MDEditor;
 }


### PR DESCRIPTION
After https://github.com/uiwjs/react-md-editor/pull/698 , even though the correct methods were being exported, you would get a typescript when trying to use them, because the `d.ts`  file is created manually and I forgot to update it. This MR fixes the issue.

Sorry about missing the manual declaration file, I just blindly assumed it's generated automatically. Will do better with future contributions to test before opening PRs.