### PR TITLE
fix: keep bold markers when applying italic

### DIFF
--- a/core/src/utils/markdownUtils.ts
+++ b/core/src/utils/markdownUtils.ts
@@ -5,6 +5,39 @@ export interface TextSection {
   selection: TextRange;
 }
 
+// `*` is a prefix of `**`, so `**text**` is bold-only and `***text***` is bold+italic.
+function isItalicInsideBoldOnly(text: string, start: number, end: number): boolean {
+  const insideBold =
+    start >= 2 && end + 2 <= text.length && text.slice(start - 2, start) === '**' && text.slice(end, end + 2) === '**';
+  if (!insideBold) {
+    return false;
+  }
+  const insideBoldItalic =
+    start >= 3 &&
+    end + 3 <= text.length &&
+    text.slice(start - 3, start) === '***' &&
+    text.slice(end, end + 3) === '***';
+  return !insideBoldItalic;
+}
+
+function isAlreadyWrapped(selectedText: string, prefix: string, suffix: string): boolean {
+  if (
+    selectedText.length < prefix.length + suffix.length ||
+    !selectedText.startsWith(prefix) ||
+    !selectedText.endsWith(suffix)
+  ) {
+    return false;
+  }
+  if (prefix === '*' && suffix === '*') {
+    const isBold = selectedText.startsWith('**') && selectedText.endsWith('**');
+    const isBoldItalic = selectedText.startsWith('***') && selectedText.endsWith('***');
+    if (isBold && !isBoldItalic) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export function selectWord({
   text,
   selection,
@@ -23,6 +56,9 @@ export function selectWord({
   if (result.start >= prefix.length && result.end <= text.length - suffix.length) {
     const selectedTextContext = text.slice(result.start - prefix.length, result.end + suffix.length);
     if (selectedTextContext.startsWith(prefix) && selectedTextContext.endsWith(suffix)) {
+      if (prefix === '*' && suffix === '*' && isItalicInsideBoldOnly(text, result.start, result.end)) {
+        return result;
+      }
       return { start: result.start - prefix.length, end: result.end + suffix.length };
     }
   }
@@ -139,11 +175,7 @@ export function executeCommand({
   prefix: string;
   suffix?: string;
 }) {
-  if (
-    selectedText.length >= prefix.length + suffix.length &&
-    selectedText.startsWith(prefix) &&
-    selectedText.endsWith(suffix)
-  ) {
+  if (isAlreadyWrapped(selectedText, prefix, suffix)) {
     api.replaceSelection(selectedText.slice(prefix.length, suffix.length ? -suffix.length : undefined));
     api.setSelectionRange({ start: selection.start - prefix.length, end: selection.end - prefix.length });
   } else {

--- a/test/commands.test.tsx
+++ b/test/commands.test.tsx
@@ -62,6 +62,64 @@ it('MDEditor commands italic', async () => {
   expect(inputNode).toHaveValue('*title*');
 });
 
+it('MDEditor commands bold then italic keeps bold markers', async () => {
+  const MyComponent = () => {
+    const [value, setValue] = React.useState('title');
+    return (
+      <MDEditor
+        value={value}
+        textareaProps={{ title: 'test' }}
+        onChange={(value) => {
+          setValue(value || '');
+        }}
+      />
+    );
+  };
+  render(<MyComponent />);
+  fireEvent(
+    screen.getByTitle('Add bold text (ctrl + b)'),
+    new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+  expect(screen.getByTitle('test')).toHaveValue('**title**');
+  fireEvent(
+    screen.getByTitle('Add italic text (ctrl + i)'),
+    new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+  expect(screen.getByTitle('test')).toHaveValue('***title***');
+});
+
+it('MDEditor commands italic inside a bold highlight keeps bold markers', async () => {
+  const MyComponent = () => {
+    const [value, setValue] = React.useState('**title**');
+    return (
+      <MDEditor
+        value={value}
+        textareaProps={{ title: 'test' }}
+        onChange={(value) => {
+          setValue(value || '');
+        }}
+      />
+    );
+  };
+  render(<MyComponent />);
+  const inputNode = screen.getByTitle<HTMLTextAreaElement>('test');
+  inputNode.setSelectionRange(2, 7);
+  fireEvent(
+    screen.getByTitle('Add italic text (ctrl + i)'),
+    new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+  expect(inputNode).toHaveValue('***title***');
+});
+
 it('MDEditor commands code', async () => {
   const handleChange = jest.fn((value) => value);
   render(<MDEditor value={`He llo \nWold!`} textareaProps={{ title: 'test' }} onChange={handleChange} />);

--- a/test/utils/markdownUtils.test.tsx
+++ b/test/utils/markdownUtils.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { executeCommand, selectWord } from '../../core/src/utils/markdownUtils';
+import type { TextAreaTextApi } from '../../core/src/commands';
+
+function createApi(initialText: string, selection: { start: number; end: number }) {
+  let text = initialText;
+  let range = { ...selection };
+  const api = {
+    replaceSelection(replacement: string) {
+      text = text.slice(0, range.start) + replacement + text.slice(range.end);
+      range = { start: range.start, end: range.start + replacement.length };
+      return {
+        text,
+        selectedText: replacement,
+        selection: range,
+      };
+    },
+    setSelectionRange(next: { start: number; end: number }) {
+      range = { ...next };
+      return {
+        text,
+        selectedText: text.slice(range.start, range.end),
+        selection: range,
+      };
+    },
+  };
+  return {
+    api: api as unknown as TextAreaTextApi,
+    getText: () => text,
+  };
+}
+
+it('selectWord does not treat bold ** as italic *', () => {
+  const text = '**hello**';
+  const selection = { start: 2, end: 7 };
+  expect(selectWord({ text, selection, prefix: '*' })).toEqual(selection);
+});
+
+it('selectWord still expands a true italic wrap', () => {
+  const text = '*hello*';
+  const selection = { start: 1, end: 6 };
+  expect(selectWord({ text, selection, prefix: '*' })).toEqual({ start: 0, end: 7 });
+});
+
+it('selectWord expands italic when already bold+italic', () => {
+  const text = '***hello***';
+  const selection = { start: 3, end: 8 };
+  expect(selectWord({ text, selection, prefix: '*' })).toEqual({ start: 2, end: 9 });
+});
+
+it('executeCommand wraps italic around bold instead of stripping bold', () => {
+  const { api, getText } = createApi('**hello**', { start: 0, end: 9 });
+  executeCommand({
+    api,
+    selectedText: '**hello**',
+    selection: { start: 0, end: 9 },
+    prefix: '*',
+  });
+  expect(getText()).toBe('***hello***');
+});
+
+it('executeCommand still unwraps italic', () => {
+  const { api, getText } = createApi('*hello*', { start: 0, end: 7 });
+  executeCommand({
+    api,
+    selectedText: '*hello*',
+    selection: { start: 0, end: 7 },
+    prefix: '*',
+  });
+  expect(getText()).toBe('hello');
+});
+
+it('executeCommand unwraps italic while keeping bold', () => {
+  const { api, getText } = createApi('***hello***', { start: 0, end: 11 });
+  executeCommand({
+    api,
+    selectedText: '***hello***',
+    selection: { start: 0, end: 11 },
+    prefix: '*',
+  });
+  expect(getText()).toBe('**hello**');
+});


### PR DESCRIPTION
## Summary
- Applying italic to already-bold text no longer strips `**`.
- Wrap detection treats `**text**` as bold-only and `***text***` as bold+italic.

Fixes #708

## Test plan
- [x] `npx tsbb test` (56 tests)
