### PR TITLE
fix: require a literal period for ordered-list Enter continuation

### DIFF
--- a/core/src/components/TextArea/handleKeyDown.tsx
+++ b/core/src/components/TextArea/handleKeyDown.tsx
@@ -102,7 +102,7 @@ export default function handleKeyDown(
   } else if (
     e.keyCode === 13 &&
     e.code.toLowerCase() === 'enter' &&
-    (/^(-|\*)\s/.test(currentLineStr) || /^\d+.\s/.test(currentLineStr)) &&
+    (/^(-|\*)\s/.test(currentLineStr) || /^\d+\.\s/.test(currentLineStr)) &&
     !e.shiftKey
   ) {
     /**
@@ -123,7 +123,7 @@ export default function handleKeyDown(
       startStr = '\n- [ ] ';
     }
 
-    if (/^\d+.\s/.test(currentLineStr)) {
+    if (/^\d+\.\s/.test(currentLineStr)) {
       startStr = `\n${parseInt(currentLineStr) + 1}. `;
     }
     return insertTextAtPosition(target, startStr);

--- a/test/handleKeyDown.test.tsx
+++ b/test/handleKeyDown.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import handleKeyDown from '../core/src/components/TextArea/handleKeyDown';
+
+function pressEnter(value: string) {
+  const textarea = document.createElement('textarea');
+  textarea.value = value;
+  textarea.selectionStart = value.length;
+  textarea.selectionEnd = value.length;
+  document.body.appendChild(textarea);
+  textarea.addEventListener('keydown', (e) => handleKeyDown(e));
+
+  const event = new KeyboardEvent('keydown', {
+    key: 'Enter',
+    code: 'Enter',
+    bubbles: true,
+    cancelable: true,
+  });
+  Object.defineProperty(event, 'keyCode', { get: () => 13 });
+  textarea.dispatchEvent(event);
+  return textarea;
+}
+
+it('does not continue an ordered list when the line is not a list marker', () => {
+  expect(pressEnter('1x text').value).toEqual('1x text');
+  expect(pressEnter('2026: year').value).toEqual('2026: year');
+  expect(pressEnter('12m von Zaun').value).toEqual('12m von Zaun');
+});
+
+it('continues a real ordered list on Enter', () => {
+  expect(pressEnter('1. item').value).toEqual('1. item\n2. ');
+});


### PR DESCRIPTION
## Summary
- Ordered-list Enter continuation now requires a literal period, not any character after digits.
- Lines like 1x, 2026:, and 12m no longer continue as ordered lists.

Fixes #703

## Test plan
- [x] npx tsbb test (58 tests)
